### PR TITLE
Replace back-and-forth multithreading communication with queue-and-catch-up system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,5 +22,5 @@ target_include_directories(main PRIVATE src/include)
 
 enable_testing()
 add_test(NAME nestest_execute COMMAND main nestest)
-set_tests_properties(nestest_execute PROPERTIES TIMEOUT 1)
+set_tests_properties(nestest_execute PROPERTIES TIMEOUT 0.2)
 add_test(NAME nestest_match COMMAND python ${CMAKE_SOURCE_DIR}/test/nestestCompare.py)

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -58,11 +58,13 @@ class CPU {
         void reset(Memory::addr_t pc=0xfffc);
         void start();
         void stop(std::thread& t);
+        void kill(std::thread& t);
         void cycle();
         uint8_t peek();
         uint16_t peekWord();
         uint8_t read();
         uint16_t readWord();
+        bool checkRunning();
 
         static addressingMode getAddressingMode(uint8_t opcode);
         static instruction getInstruction(uint8_t opcode);
@@ -102,9 +104,11 @@ class CPU {
         bool waitForCycles(int n);
         bool waitForCycle();
         std::atomic<bool> running;
+        std::atomic<bool> notDone;
 
-        // 0 is new cycle started, 1 is running, 2 is done
-        int cycleStatus;
+        int maxCycles;
+        int cyclesRequested; // uses cycleStatusMutex
+        std::atomic<int> cyclesExecuted;
         std::mutex cycleStatusMutex;
         std::condition_variable cycleStatusCV;
 


### PR DESCRIPTION
This makes the multithreaded approach a good deal faster, much closer to the original single-threaded performance.